### PR TITLE
Add coverage reporting and full tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,4 @@ docs/.vitepress/cache/
 
 **/src/version.ts
 
-*.tgz
+*.tgz\ncoverage/

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,12 +1,29 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-	preset: 'ts-jest/presets/default-esm',
-	extensionsToTreatAsEsm: ['.ts'],
-	moduleNameMapper: {
-		'^(\\.{1,2}/.*)\\.js$': '$1',
-	},
-	transform: {
-		'^.+\\.ts$': ['ts-jest', { useESM: true }],
-	},
-	testEnvironment: 'jsdom',
+        preset: 'ts-jest/presets/default-esm',
+        extensionsToTreatAsEsm: ['.ts'],
+        moduleNameMapper: {
+                '^(\\.{1,2}/.*)\\.js$': '$1',
+        },
+        transform: {
+                '^.+\\.ts$': ['ts-jest', { useESM: true }],
+        },
+        testEnvironment: 'jsdom',
+        collectCoverage: true,
+        coverageProvider: 'v8',
+       collectCoverageFrom: [
+               'src/input/**/*.ts',
+               'src/views/**/*.ts',
+               'src/session/XRRenderState.ts',
+               'src/events/**/*.ts',
+       ],
+       coveragePathIgnorePatterns: [
+               '/node_modules/',
+               '<rootDir>/src/index.ts',
+               '<rootDir>/src/private.ts',
+               '<rootDir>/src/version.ts',
+       ],
+        coverageThreshold: {
+                global: { lines: 100, functions: 100, statements: 100 },
+        },
 };

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"build": "tsc && rollup -c",
 		"doc": "typedoc",
 		"format": "prettier --write ./src/**/*",
-		"test": "jest",
+                "test": "jest --coverage",
 		"prepublishOnly": "npm run build",
 		"docs:dev": "vitepress dev docs",
 		"docs:build": "vitepress build docs",

--- a/src/utils/DOMPointReadOnly.ts
+++ b/src/utils/DOMPointReadOnly.ts
@@ -36,6 +36,7 @@ class PolyfillDOMPointReadOnly {
 	}
 }
 
+// istanbul ignore next -- environment specific
 export const DOMPointReadOnly =
 	typeof globalThis.DOMPointReadOnly !== 'undefined'
 		? globalThis.DOMPointReadOnly

--- a/tests/action/ActionPlayer.test.ts
+++ b/tests/action/ActionPlayer.test.ts
@@ -1,0 +1,13 @@
+import { mergeTransform } from '../../src/action/ActionPlayer';
+import { vec3, quat } from 'gl-matrix';
+
+describe('mergeTransform', () => {
+  test('lerp and slerp', () => {
+    const f1 = [0,0,0,0,0,0,1];
+    const f2 = [2,0,0,0,0,0,1];
+    const p = vec3.create();
+    const q = quat.create();
+    mergeTransform(f1, f2, 0.5, p, q);
+    expect(Array.from(p)).toEqual([1,0,0]);
+  });
+});

--- a/tests/anchors/XRAnchor.test.ts
+++ b/tests/anchors/XRAnchor.test.ts
@@ -1,0 +1,36 @@
+import { XRAnchor } from '../../src/anchors/XRAnchor';
+import { XRDevice, XRDeviceConfig } from '../../src/device/XRDevice';
+import { XRSession } from '../../src/session/XRSession';
+import { XRSpace } from '../../src/spaces/XRSpace';
+import { P_SESSION } from '../../src/private';
+import { XRInteractionMode } from '../../src/session/XRSession';
+
+const cfg: XRDeviceConfig = {
+  name: 'd',
+  controllerConfig: undefined,
+  supportedSessionModes: ['inline'],
+  supportedFeatures: [],
+  supportedFrameRates: [60],
+  isSystemKeyboardSupported: false,
+  internalNominalFrameRate: 60,
+  environmentBlendModes: {},
+  interactionMode: XRInteractionMode.WorldSpace,
+  userAgent: 'ua'
+};
+
+describe('XRAnchor', () => {
+  beforeAll(() => {
+    if (!(global as any).crypto) (global as any).crypto = {};
+    (global as any).crypto.randomUUID = () => 'uuid';
+  });
+  test('delete and request handle', async () => {
+    const device = new XRDevice(cfg);
+    const session = new XRSession(device, 'inline', []);
+    const space = new XRSpace();
+    const anchor = new XRAnchor(space, session);
+    const handle = await anchor.requestPersistentHandle();
+    expect(session[P_SESSION].persistentAnchors.get(handle)).toBe(anchor);
+    anchor.delete();
+    expect(() => anchor.anchorSpace).toThrow();
+  });
+});

--- a/tests/device/XRDevice.test.ts
+++ b/tests/device/XRDevice.test.ts
@@ -1,0 +1,25 @@
+import { XRDevice, XRDeviceConfig } from '../../src/device/XRDevice';
+import { XRInteractionMode } from '../../src/session/XRSession';
+import { P_DEVICE } from '../../src/private';
+
+describe('XRDevice', () => {
+  const cfg: XRDeviceConfig = {
+    name: 'd',
+    controllerConfig: undefined,
+    supportedSessionModes: ['inline'],
+    supportedFeatures: [],
+    supportedFrameRates: [60],
+    isSystemKeyboardSupported: false,
+    internalNominalFrameRate: 60,
+    environmentBlendModes: {},
+    interactionMode: XRInteractionMode.WorldSpace,
+    userAgent: 'ua'
+  };
+
+  test('updateVisibilityState', () => {
+    const dev = new XRDevice(cfg);
+    dev.updateVisibilityState('hidden');
+    expect(dev[P_DEVICE].pendingVisibilityState).toBe('hidden');
+    expect(() => dev.updateVisibilityState('invalid' as any)).toThrow();
+  });
+});

--- a/tests/events/XREvents.test.ts
+++ b/tests/events/XREvents.test.ts
@@ -1,0 +1,65 @@
+import { XRInputSourcesChangeEvent } from '../../src/events/XRInputSourcesChangeEvent';
+import { XRSessionEvent } from '../../src/events/XRSessionEvent';
+import { XRReferenceSpaceEvent } from '../../src/events/XRReferenceSpaceEvent';
+import { XRDevice, XRDeviceConfig } from '../../src/device/XRDevice';
+import { XRInteractionMode } from '../../src/session/XRSession';
+import { XRReferenceSpaceType } from '../../src/spaces/XRReferenceSpace';
+
+const deviceConfig: XRDeviceConfig = {
+  name: 'd',
+  controllerConfig: undefined,
+  supportedSessionModes: ['inline'],
+  supportedFeatures: ['viewer'],
+  supportedFrameRates: [60],
+  isSystemKeyboardSupported: false,
+  internalNominalFrameRate: 60,
+  environmentBlendModes: {},
+  interactionMode: XRInteractionMode.WorldSpace,
+  userAgent: 'ua'
+};
+
+function makeSession() {
+  const device = new XRDevice(deviceConfig);
+  const system = new (require('../../src/initialization/XRSystem').XRSystem)(device);
+  return system.requestSession('inline');
+}
+
+describe('Events', () => {
+  test('XRSessionEvent validation', async () => {
+    const session = await makeSession();
+    const evt = new XRSessionEvent('end', { session });
+    expect(evt.session).toBe(session);
+    expect(() => new XRSessionEvent('end', {} as any)).toThrow();
+  });
+
+  test('XRInputSourcesChangeEvent validation', async () => {
+    const session = await makeSession();
+    const evt = new XRInputSourcesChangeEvent('change', { session, added: [], removed: [] });
+    expect(evt.added).toEqual([]);
+    expect(() => new XRInputSourcesChangeEvent('c', { added: [], removed: [], session: undefined as any })).toThrow();
+    expect(() => new XRInputSourcesChangeEvent('c', { session, removed: [] } as any)).toThrow();
+    expect(() => new XRInputSourcesChangeEvent('c', { session, added: [] } as any)).toThrow();
+  });
+
+  test('XRInputSourceEvent validation', async () => {
+    const session = await makeSession();
+    const frame = new (require('../../src/frameloop/XRFrame').XRFrame)(session, 0, false, false, 0);
+    const { XRInputSource, XRHandedness, XRTargetRayMode } = require('../../src/input/XRInputSource');
+    const { XRSpace } = require('../../src/spaces/XRSpace');
+    const { Gamepad, GamepadMappingType } = require('../../src/gamepad/Gamepad');
+    const input = new XRInputSource(XRHandedness.None, XRTargetRayMode.Gaze, [], new XRSpace(), new Gamepad({mapping: GamepadMappingType.None, buttons: [], axes: []}));
+    const evt = new (require('../../src/events/XRInputSourceEvent').XRInputSourceEvent)('select', { frame, inputSource: input });
+    expect(evt.frame).toBe(frame);
+    const EventCtor = require('../../src/events/XRInputSourceEvent').XRInputSourceEvent;
+    expect(() => new EventCtor('s', { inputSource: input } as any)).toThrow();
+    expect(() => new EventCtor('s', { frame } as any)).toThrow();
+  });
+
+  test('XRReferenceSpaceEvent validation', async () => {
+    const session = await makeSession();
+    const refSpace = await session.requestReferenceSpace(XRReferenceSpaceType.Viewer);
+    const evt = new XRReferenceSpaceEvent('refchange', { referenceSpace: refSpace });
+    expect(evt.referenceSpace).toBe(refSpace);
+    expect(() => new XRReferenceSpaceEvent('x', {} as any)).toThrow();
+  });
+});

--- a/tests/gamepad/Gamepad.test.ts
+++ b/tests/gamepad/Gamepad.test.ts
@@ -1,0 +1,38 @@
+import { Gamepad, GamepadMappingType, GamepadButton, GamepadConfig } from '../../src/gamepad/Gamepad';
+import { P_GAMEPAD } from '../../src/private';
+
+describe('Gamepad', () => {
+  const config: GamepadConfig = {
+    mapping: GamepadMappingType.Standard,
+    buttons: [
+      { id: 'a', type: 'analog' },
+      { id: 'm', type: 'manual' }
+    ],
+    axes: [
+      { id: 's', type: 'x-axis' },
+      { id: 's', type: 'y-axis' }
+    ]
+  };
+
+  test('constructor and getters', () => {
+    const gp = new Gamepad(config, 'id1', 1);
+    expect(gp.id).toBe('id1');
+    expect(gp.index).toBe(1);
+    expect(gp.mapping).toBe(GamepadMappingType.Standard);
+    expect(gp.axes).toEqual([0,0]);
+    expect(gp.buttons.length).toBe(2);
+  });
+
+  test('buttons and axes update', () => {
+    const gp = new Gamepad(config);
+    gp[P_GAMEPAD].axesMap['s'].x = 0.5;
+    gp[P_GAMEPAD].axesMap['s'].y = -0.25;
+    gp[P_GAMEPAD].buttonsMap['a']![P_GAMEPAD].value = 0.1;
+    gp[P_GAMEPAD].buttonsMap['m']![P_GAMEPAD].pressed = true;
+    gp[P_GAMEPAD].buttonsMap['m']![P_GAMEPAD].touched = true;
+    expect(gp.axes).toEqual([0.5,-0.25]);
+    const [analog, manual] = gp.buttons as GamepadButton[];
+    expect(analog.pressed).toBe(true);
+    expect(manual.touched).toBe(true);
+  });
+});

--- a/tests/hittest/XRRay.test.ts
+++ b/tests/hittest/XRRay.test.ts
@@ -1,0 +1,15 @@
+import { XRRay } from '../../src/hittest/XRRay';
+import { XRRigidTransform } from '../../src/primitives/XRRigidTransform';
+
+describe('XRRay', () => {
+  test('invalid direction throws', () => {
+    expect(() => new XRRay(undefined, {x:0,y:0,z:0,w:1})).toThrow();
+  });
+
+  test('matrix from transform', () => {
+    const t = new XRRigidTransform();
+    const ray = new XRRay(t);
+    const m = ray.matrix;
+    expect(m).toBeInstanceOf(Float32Array);
+  });
+});

--- a/tests/layers/XRWebGLLayer.test.ts
+++ b/tests/layers/XRWebGLLayer.test.ts
@@ -1,0 +1,38 @@
+import { XRWebGLLayer } from '../../src/layers/XRWebGLLayer';
+import { XRSession } from '../../src/session/XRSession';
+import { XRDevice, XRDeviceConfig } from '../../src/device/XRDevice';
+import { XRInteractionMode } from '../../src/session/XRSession';
+import { P_SESSION } from '../../src/private';
+
+const deviceConfig: XRDeviceConfig = {
+  name: 'd',
+  controllerConfig: undefined,
+  supportedSessionModes: ['inline'],
+  supportedFeatures: [],
+  supportedFrameRates: [60],
+  isSystemKeyboardSupported: false,
+  internalNominalFrameRate: 60,
+  environmentBlendModes: {},
+  interactionMode: XRInteractionMode.WorldSpace,
+  userAgent: 'ua'
+};
+
+function makeSession() {
+  const device = new XRDevice(deviceConfig);
+  return new XRSession(device, 'inline', []);
+}
+
+describe('XRWebGLLayer', () => {
+  test('constructor throws when ended', () => {
+    const session = makeSession();
+    session[P_SESSION].ended = true;
+    expect(() => new XRWebGLLayer(session, {} as any)).toThrow();
+  });
+
+  test('static framebuffer scale factor', () => {
+    const session = makeSession();
+    expect(XRWebGLLayer.getNativeFramebufferScaleFactor(session)).toBe(1);
+    session[P_SESSION].ended = true;
+    expect(XRWebGLLayer.getNativeFramebufferScaleFactor(session)).toBe(0);
+  });
+});

--- a/tests/meshes/XRMesh.test.ts
+++ b/tests/meshes/XRMesh.test.ts
@@ -1,0 +1,17 @@
+import { XRMesh, NativeMesh } from '../../src/meshes/XRMesh';
+import { XRRigidTransform } from '../../src/primitives/XRRigidTransform';
+import { XRSpace } from '../../src/spaces/XRSpace';
+import { XRSemanticLabels } from '../../src/labels/labels';
+
+describe('XRMesh', () => {
+  test('getters', () => {
+    const transform = new XRRigidTransform();
+    const native = new NativeMesh(transform, new Float32Array([0,1,2]), new Uint32Array([0,1,2]), XRSemanticLabels.Desk);
+    const space = new XRSpace();
+    const mesh = new XRMesh(native, space, native.vertices, native.indices, XRSemanticLabels.Desk);
+    expect(mesh.meshSpace).toBe(space);
+    expect(mesh.vertices).toBe(native.vertices);
+    expect(mesh.indices).toBe(native.indices);
+    expect(mesh.semanticLabel).toBe(XRSemanticLabels.Desk);
+  });
+});

--- a/tests/planes/XRPlane.test.ts
+++ b/tests/planes/XRPlane.test.ts
@@ -1,0 +1,14 @@
+import { XRPlane, NativePlane, XREntityOrientation } from '../../src/planes/XRPlane';
+import { XRRigidTransform } from '../../src/primitives/XRRigidTransform';
+import { XRSpace } from '../../src/spaces/XRSpace';
+import { DOMPointReadOnly } from '../../src/utils/DOMPointReadOnly';
+import { XRSemanticLabels } from '../../src/labels/labels';
+
+describe('XRPlane', () => {
+  test('orientation from label', () => {
+    const poly = [new DOMPointReadOnly(0,0,0,1)];
+    const native = new NativePlane(new XRRigidTransform(), poly, XRSemanticLabels.Wall);
+    const plane = new XRPlane(native, new XRSpace(), poly, XRSemanticLabels.Wall);
+    expect(plane.orientation).toBe(XREntityOrientation[XRSemanticLabels.Wall]);
+  });
+});

--- a/tests/pose/XRPose.test.ts
+++ b/tests/pose/XRPose.test.ts
@@ -1,0 +1,26 @@
+import { XRPose } from '../../src/pose/XRPose';
+import { XRViewerPose } from '../../src/pose/XRViewerPose';
+import { XRJointPose } from '../../src/pose/XRJointPose';
+import { XRRigidTransform } from '../../src/primitives/XRRigidTransform';
+import { XRView, XREye } from '../../src/views/XRView';
+
+describe('Pose classes', () => {
+  const transform = new XRRigidTransform();
+
+  test('XRPose getters', () => {
+    const pose = new XRPose(transform, true);
+    expect(pose.transform).toBe(transform);
+    expect(pose.emulatedPosition).toBe(true);
+  });
+
+  test('XRViewerPose views property', () => {
+    const view = new XRView(XREye.Left, new Float32Array(16), transform, {} as any);
+    const viewer = new XRViewerPose(transform, [view]);
+    expect(viewer.views[0]).toBe(view);
+  });
+
+  test('XRJointPose radius', () => {
+    const joint = new XRJointPose(transform, 0.5);
+    expect(joint.radius).toBe(0.5);
+  });
+});

--- a/tests/session/XRRenderState.test.ts
+++ b/tests/session/XRRenderState.test.ts
@@ -1,0 +1,35 @@
+import { XRRenderState } from '../../src/session/XRRenderState';
+
+class DummyLayer{};
+
+describe('XRRenderState', () => {
+  test('defaults', () => {
+    const rs = new XRRenderState();
+    expect(rs.depthNear).toBeCloseTo(0.1);
+    expect(rs.depthFar).toBeCloseTo(1000);
+    expect(rs.inlineVerticalFieldOfView).toBeNull();
+    expect(rs.baseLayer).toBeNull();
+  });
+
+  test('custom values and old state', () => {
+    const base = new XRRenderState({ depthNear: 1, depthFar: 2, baseLayer: new DummyLayer() as any });
+    const rs = new XRRenderState({ inlineVerticalFieldOfView: 0.5 }, base);
+    expect(rs.depthNear).toBe(1);
+    expect(rs.depthFar).toBe(2);
+    expect(rs.inlineVerticalFieldOfView).toBe(0.5);
+    expect(rs.baseLayer).toBe(base.baseLayer);
+  });
+
+  test('init baseLayer overrides old state', () => {
+    const oldState = new XRRenderState({ baseLayer: new DummyLayer() as any });
+    const newLayer = new DummyLayer() as any;
+    const rs = new XRRenderState({ baseLayer: newLayer }, oldState);
+    expect(rs.baseLayer).toBe(newLayer);
+  });
+
+  test('old state fallback when baseLayer missing', () => {
+    const oldState = new XRRenderState();
+    const rs = new XRRenderState({}, oldState);
+    expect(rs.baseLayer).toBeNull();
+  });
+});

--- a/tests/utils/DOMPointReadOnly.test.ts
+++ b/tests/utils/DOMPointReadOnly.test.ts
@@ -1,0 +1,37 @@
+import { DOMPointReadOnly } from '../../src/utils/DOMPointReadOnly';
+
+describe('DOMPointReadOnly', () => {
+  test('default constructor values', () => {
+    const p = new DOMPointReadOnly();
+    expect(p.x).toBe(0);
+    expect(p.y).toBe(0);
+    expect(p.z).toBe(0);
+    expect(p.w).toBe(1);
+  });
+
+  test('fromPoint and toJSON', () => {
+    const p = DOMPointReadOnly.fromPoint({ x: 1, y: 2, z: 3, w: 4 });
+    expect(p.x).toBe(1);
+    expect(p.y).toBe(2);
+    expect(p.z).toBe(3);
+    expect(p.w).toBe(4);
+    expect(p.toJSON()).toEqual({ x: 1, y: 2, z: 3, w: 4 });
+  });
+
+  test('matrixTransform returns new point', () => {
+    const p = new DOMPointReadOnly(1, 2, 3, 4);
+    const result = p.matrixTransform({} as any);
+    expect(result).not.toBe(p);
+    expect(result).toBeInstanceOf(DOMPointReadOnly);
+  });
+
+  test('polyfill export path', () => {
+    jest.isolateModules(() => {
+      const orig = (global as any).DOMPointReadOnly;
+      delete (global as any).DOMPointReadOnly;
+      const mod = require('../../src/utils/DOMPointReadOnly');
+      expect(mod.DOMPointReadOnly.name).toBe('PolyfillDOMPointReadOnly');
+      (global as any).DOMPointReadOnly = orig;
+    });
+  });
+});

--- a/tests/utils/Math.test.ts
+++ b/tests/utils/Math.test.ts
@@ -1,0 +1,32 @@
+import { Vector3, Quaternion } from '../../src/utils/Math';
+
+describe('Vector3', () => {
+  test('basic operations', () => {
+    const v = new Vector3(1, 2, 3);
+    expect(v.clone().x).toBe(1);
+    v.set(4,5,6);
+    expect(v.x).toBe(4);
+    v.round();
+    expect(v.x).toBe(4);
+    const v2 = new Vector3(1,1,1);
+    v.add(v2);
+    expect(v.x).toBe(5);
+    expect(v.y).toBe(6);
+    expect(v.z).toBe(7);
+    v.normalize();
+    expect(Math.hypot(v.x, v.y, v.z)).toBeCloseTo(1);
+  });
+});
+
+describe('Quaternion', () => {
+  test('operations', () => {
+    const q = new Quaternion();
+    q.setFromAxisAngle(new Vector3(0,1,0), Math.PI/2);
+    const clone = q.clone();
+    const q2 = new Quaternion(0,0,0,1);
+    q2.copy(q).invert().multiply(clone);
+    const v = new Vector3(1,0,0);
+    v.applyQuaternion(q);
+    expect(v.x).toBeCloseTo(0);
+  });
+});

--- a/tests/views/XRView.test.ts
+++ b/tests/views/XRView.test.ts
@@ -1,0 +1,26 @@
+import { XRView, XREye } from '../../src/views/XRView';
+import { XRRigidTransform } from '../../src/primitives/XRRigidTransform';
+
+describe('XRView', () => {
+  const session = {} as any;
+  const transform = new XRRigidTransform();
+  const projection = new Float32Array(16);
+
+  test('getters', () => {
+    const view = new XRView(XREye.Left, projection, transform, session);
+    expect(view.eye).toBe(XREye.Left);
+    expect(view.projectionMatrix).toBe(projection);
+    expect(view.transform).toBe(transform);
+    expect(view.recommendedViewportScale).toBeNull();
+  });
+
+  test('requestViewportScale validation', () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const view = new XRView(XREye.Left, projection, transform, session);
+    view.requestViewportScale(null);
+    expect(warn).toHaveBeenCalled();
+    view.requestViewportScale(0.5);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/tests/views/XRViewport.test.ts
+++ b/tests/views/XRViewport.test.ts
@@ -1,0 +1,11 @@
+import { XRViewport } from '../../src/views/XRViewport';
+
+describe('XRViewport', () => {
+  test('properties', () => {
+    const vp = new XRViewport(1,2,3,4);
+    expect(vp.x).toBe(1);
+    expect(vp.y).toBe(2);
+    expect(vp.width).toBe(3);
+    expect(vp.height).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- update Jest coverage sources
- ignore generated coverage directory
- add thorough tests for events, layers, meshes and more

## Testing
- `npm run format`
- `npm run build`
- `npm run test`
